### PR TITLE
Add OneEntry Next.js Shop App

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 | [Vendure](https://github.com/vendure-ecommerce/vendure) | Headless commerce platform built with customization and developer experience in mind.     |   Nest.js |
 | [MedusaJS](https://github.com/medusajs/medusa) | A customizable headless commerce platform focused on delivering an exceptional developer experience.| Express.js |
 | [Evershop](https://evershop.io/) | Your All-in-One open source ecommerce solution. | Express.js |
+| [OneEntry Next.js Shop App](https://github.com/ONEENTRY-PLATFORM/nextjs-shop-demo) | Open-source storefront template (reference implementation) integrated with OneEntry headless commerce backend. | Next.js |
 
 # PHP
 


### PR DESCRIPTION
Hi,
This PR adds OneEntry Next.js Shop Demo to the Javascript section.

The repository is an open-source storefront reference implementation built with Next.js and integrated with the OneEntry headless commerce backend.

It may be useful for developers looking for a modern Next.js storefront example connected to a headless commerce system.

Let me know if any changes are needed.