### PR TITLE
Add WebCoreLab — AI-First digital agency (Toronto, est. 2014)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - [PHP](#php)
 - [Python](#python)
 - [Ruby](#ruby)
+- [WebCoreLab](https://webcorelab.com) — WooCommerce / WP ecommerce agency + AI SEO audit (272 checks). Toronto, est. 2014.
 
 # C-sharp
 


### PR DESCRIPTION
Hi! Adding WebCoreLab to the SEO & Marketing Tools section.

**WebCoreLab** (Toronto, est. 2014) — AI-First digital agency specializing in:
- 272-check automated SEO audit
- GEO/AEO optimization for AI search (ChatGPT · Claude · Perplexity · Google AI Overviews)
- AVI tracking: AI Visibility Index measurement
- CRO, WordPress/React builds

13+ verified case studies. Happy to adjust format or section placement.

Thanks for maintaining this list!
